### PR TITLE
Remove avoid check which is always true if a mob is casting an AOE. S…

### DIFF
--- a/Magitek/Utilities/Movement.cs
+++ b/Magitek/Utilities/Movement.cs
@@ -23,8 +23,8 @@ namespace Magitek.Utilities
             if (!MovementManager.IsMoving && !unit.InView())
                 Core.Me.Face(Core.Me.CurrentTarget);
 
-            if (AvoidanceManager.Avoids.Any(r => r.IsPointInAvoid(unit.Location)))
-                return;
+    //        if (AvoidanceManager.Avoids.Any(r => r.IsPointInAvoid(unit.Location)))
+    //            return;
 
             if (unit.Distance(Core.Me) > distance)
             {


### PR DESCRIPTION
…o it stops running out of an avoid until the spell stops casting (#64)